### PR TITLE
feat(reservation/payment): 예약취소 시 결제취소(카카오페이 환불) 연동 기능 추가

### DIFF
--- a/src/main/java/com/example/airbnbproject/controller/ReservationController.java
+++ b/src/main/java/com/example/airbnbproject/controller/ReservationController.java
@@ -12,6 +12,7 @@ import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
 import javax.servlet.http.HttpSession;
 import javax.validation.Valid;
@@ -100,5 +101,21 @@ public class ReservationController {
             }
         }
         return list;
+    }
+
+    @PostMapping("/{id}/cancel")
+    public String cancelReservation(@PathVariable Long id,
+                                    HttpSession session,
+                                    RedirectAttributes ra) {
+        User user = (User) session.getAttribute("user");
+        try {
+            reservationService.cancelOrRefund(id, user); // ▼ 2) 서비스 구현
+            ra.addFlashAttribute("msg", "예약이 취소되었습니다.");
+        } catch (IllegalArgumentException e) {
+            ra.addFlashAttribute("msg", e.getMessage());
+        } catch (IllegalStateException e) {
+            ra.addFlashAttribute("msg", "결제 취소 중 오류가 발생했습니다. 잠시 후 다시 시도해주세요.");
+        }
+        return "redirect:/reservation/" + id;
     }
 }

--- a/src/main/java/com/example/airbnbproject/domain/Payment.java
+++ b/src/main/java/com/example/airbnbproject/domain/Payment.java
@@ -10,7 +10,7 @@ import java.time.LocalDateTime;
 @Getter @Setter
 @Table(indexes = {
         @Index(name = "idx_payment_reservation", columnList = "reservation_id"),
-        @Index(name = "ux_payment_tid", columnList = "tid", unique = true)
+        @Index(name = "idx_payment_tid",        columnList = "tid") // ✅ 일반 인덱스
 })
 public class Payment {
 
@@ -28,11 +28,11 @@ public class Payment {
     @Column(nullable = false)
     private PaymentStatus status;
 
-    @Column(length = 100, unique = true)
-    private String tid;  // null 허용(취소/실패 로그엔 없을 수 있음)
+    @Column(length = 100) // ✅ unique 제거 (nullable은 기본 true)
+    private String tid;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "reservation_id", nullable = false)
     private Reservation reservation;
-
 }
+

--- a/src/main/java/com/example/airbnbproject/domain/PaymentStatus.java
+++ b/src/main/java/com/example/airbnbproject/domain/PaymentStatus.java
@@ -1,6 +1,6 @@
 package com.example.airbnbproject.domain;
 
 public enum PaymentStatus {
-    PAID, FAILED, CANCELLED
+    PAID, FAILED, CANCELED
 }
 

--- a/src/main/java/com/example/airbnbproject/dto/KakaoPayCancelRequestDto.java
+++ b/src/main/java/com/example/airbnbproject/dto/KakaoPayCancelRequestDto.java
@@ -1,0 +1,17 @@
+package com.example.airbnbproject.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class KakaoPayCancelRequestDto {
+    private String cid;
+    private String tid;
+    private Integer cancel_amount;
+    private Integer cancel_tax_free_amount;
+}

--- a/src/main/java/com/example/airbnbproject/dto/KakaoPayCancelResponseDto.java
+++ b/src/main/java/com/example/airbnbproject/dto/KakaoPayCancelResponseDto.java
@@ -1,0 +1,26 @@
+package com.example.airbnbproject.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+
+@Data
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class KakaoPayCancelResponseDto {
+
+    @JsonProperty("tid")
+    private String tid;
+
+    @JsonProperty("canceled_amount")
+    private CanceledAmount canceledAmount;
+
+    @JsonProperty("status")
+    private String status; // 써도 되고 안 써도 됨
+
+    @Data
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class CanceledAmount {
+        @JsonProperty("total")
+        private Integer total; // 꼭 필요한 것만
+    }
+}

--- a/src/main/java/com/example/airbnbproject/repository/PaymentRepository.java
+++ b/src/main/java/com/example/airbnbproject/repository/PaymentRepository.java
@@ -1,11 +1,16 @@
 package com.example.airbnbproject.repository;
 
 import com.example.airbnbproject.domain.Payment;
+import com.example.airbnbproject.domain.PaymentStatus;
+import com.example.airbnbproject.domain.Reservation;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
 
 @Repository
 public interface PaymentRepository extends JpaRepository<Payment, Long> {
     boolean existsByTid(String tid);
+    Optional<Payment> findTopByReservationAndStatusOrderByPaymentDateDesc(Reservation reservation, PaymentStatus status);
 }
 

--- a/src/main/webapp/WEB-INF/views/reservation.jsp
+++ b/src/main/webapp/WEB-INF/views/reservation.jsp
@@ -24,18 +24,32 @@
         <p><strong>상태:</strong> <c:out value="${reservation.status}"/></p>
     </div>
 
-    <!-- ✅ RESERVED 상태에서만 결제 버튼 노출 -->
     <c:if test="${reservation.status == 'RESERVED'}">
         <form method="post" action="/payment/kakao">
             <input type="hidden" name="reservationId" value="${reservation.id}"/>
             <button type="submit" class="btn">카카오페이로 결제</button>
         </form>
+
+        <form method="post" action="/reservation/${reservation.id}/cancel">
+            <input type="hidden" name="reservationId" value="${reservation.id}"/>
+            <button type="submit" class="btn cancel">예약 취소</button>
+        </form>
     </c:if>
 
-    <!-- 이미 결제 완료면 안내 -->
+    <!-- ✅ PAID 상태: 결제 취소 + 예약 취소 버튼 -->
     <c:if test="${reservation.status == 'PAID'}">
         <div class="alert">이미 결제 완료된 예약입니다.</div>
+        <form method="post" action="/reservation/${reservation.id}/cancel">
+            <input type="hidden" name="reservationId" value="${reservation.id}"/>
+            <button type="submit" class="btn cancel">예약 & 결제 취소</button>
+        </form>
     </c:if>
+
+    <!-- ✅ CANCELED 상태 -->
+    <c:if test="${reservation.status == 'CANCELED'}">
+        <div class="alert">이미 취소된 예약입니다.</div>
+    </c:if>
+
 </div>
 
 </body>


### PR DESCRIPTION
## 💡 작업 내용
- ReservationController: 예약취소 엔드포인트 추가 (`/reservation/{id}/cancel`)
- ReservationService: 예약 상태에 따라
  - RESERVED → 단순 취소
  - PAID → KakaoPayService 호출 후 환불 처리
- KakaoPayService: `/online/v1/payment/cancel` API 연동, 환불 성공 시 Payment 로그 적재
- Payment/PaymentStatus/PaymentRepository: 취소/환불 로직에 맞게 확장
- reservation.jsp: 예약취소/예약+결제취소 버튼 추가