### PR TITLE
feat(security,payment,admin): 하드닝 & 배포 준비(시크릿 외부화·검증·멱등·에러뷰)

### DIFF
--- a/src/main/java/com/example/airbnbproject/config/CustomErrorController.java
+++ b/src/main/java/com/example/airbnbproject/config/CustomErrorController.java
@@ -1,0 +1,38 @@
+package com.example.airbnbproject.config;
+
+import org.springframework.boot.web.servlet.error.ErrorController;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+import javax.servlet.RequestDispatcher;
+import javax.servlet.http.HttpServletRequest;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+
+@Controller
+public class CustomErrorController implements ErrorController {
+
+    @RequestMapping("/error")
+    public String handleError(HttpServletRequest request, Model model) {
+        Object sc = request.getAttribute(RequestDispatcher.ERROR_STATUS_CODE);
+        int status = (sc == null) ? 500 : Integer.parseInt(sc.toString());
+
+        // 요청 경로 (에러가 발생한 URI)
+        String rawPath = (String) request.getAttribute(RequestDispatcher.ERROR_REQUEST_URI);
+        String decodedPath = rawPath != null ? URLDecoder.decode(rawPath, StandardCharsets.UTF_8) : null;
+
+        // 에러 메시지
+        String msg = (String) request.getAttribute(RequestDispatcher.ERROR_MESSAGE);
+
+        // 모델에 값 넣기
+        model.addAttribute("status", status);
+        model.addAttribute("path", decodedPath);
+        if (msg != null) model.addAttribute("message", msg);
+
+        // 상태 코드별 페이지 선택
+        if (status == 404) return "error/404";
+        if (status >= 500) return "error/500";
+        return "error/error";
+    }
+}

--- a/src/main/java/com/example/airbnbproject/config/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/airbnbproject/config/GlobalExceptionHandler.java
@@ -1,0 +1,53 @@
+package com.example.airbnbproject.config;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.OptimisticLockingFailureException;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+
+import javax.naming.AuthenticationException;
+import javax.servlet.http.HttpServletResponse;
+import java.nio.file.AccessDeniedException;
+
+@Slf4j
+@ControllerAdvice(annotations = Controller.class)
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(AccessDeniedException.class)
+    public String handleAccessDenied(AccessDeniedException ex, HttpServletResponse res, Model model) {
+        res.setStatus(HttpServletResponse.SC_FORBIDDEN); // 403
+        model.addAttribute("message", ex.getMessage());
+        return "error/error";
+    }
+
+    @ExceptionHandler(IllegalArgumentException.class)
+    public String handleBadRequest(IllegalArgumentException ex, HttpServletResponse res, Model model) {
+        res.setStatus(HttpServletResponse.SC_BAD_REQUEST); // 400
+        model.addAttribute("message", ex.getMessage());
+        return "error/error";
+    }
+
+    @ExceptionHandler({OptimisticLockingFailureException.class})
+    public String handleConflict(RuntimeException ex, HttpServletResponse res, Model model) {
+        res.setStatus(HttpServletResponse.SC_CONFLICT); // 409
+        model.addAttribute("message", "요청이 중복되었거나 다른 요청과 충돌했습니다. 다시 시도해주세요.");
+        return "error/error";
+    }
+
+    @ExceptionHandler(AuthenticationException.class)
+    public String handleAuth(AuthenticationException ex, HttpServletResponse res, Model model) {
+        res.setStatus(HttpServletResponse.SC_UNAUTHORIZED); // 401
+        model.addAttribute("message", "인증이 필요합니다.");
+        return "error/error";
+    }
+
+    @ExceptionHandler(Exception.class)
+    public String handleAll(Exception ex, HttpServletResponse res, Model model) {
+        log.error("Unexpected error", ex);
+        res.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR); // 500
+        model.addAttribute("message", "서버 내부 오류가 발생했습니다.");
+        return "error/error";
+    }
+}

--- a/src/main/java/com/example/airbnbproject/config/KakaoPayConfig.java
+++ b/src/main/java/com/example/airbnbproject/config/KakaoPayConfig.java
@@ -8,7 +8,7 @@ import org.springframework.stereotype.Component;
 @Getter
 @Setter
 @Component
-@ConfigurationProperties(prefix = "spring.kakaopay")
+@ConfigurationProperties(prefix = "kakaopay")
 public class KakaoPayConfig {
     private String host;
     private String secretKey;

--- a/src/main/java/com/example/airbnbproject/config/WebConfig.java
+++ b/src/main/java/com/example/airbnbproject/config/WebConfig.java
@@ -26,4 +26,5 @@ public class WebConfig implements WebMvcConfigurer {
                         "/css/**", "/js/**", "/images/**", "/favicon.ico"
                 );
     }
+
 }

--- a/src/main/java/com/example/airbnbproject/controller/AccountController.java
+++ b/src/main/java/com/example/airbnbproject/controller/AccountController.java
@@ -107,7 +107,7 @@ public class AccountController {
             accountService.changePassword(user.getId(), dto);
             ra.addFlashAttribute("msg", "비밀번호가 변경되었습니다. 다시 로그인해주세요.");
             session.invalidate();
-            return "redirect:/login";
+            return "redirect:/?auth=login";
         } catch (IllegalArgumentException e) {
             br.reject("passwordError", e.getMessage());
             return "passwordChange";

--- a/src/main/java/com/example/airbnbproject/domain/AccommodationStatus.java
+++ b/src/main/java/com/example/airbnbproject/domain/AccommodationStatus.java
@@ -4,5 +4,6 @@ public enum AccommodationStatus {
     PENDING,
     APPROVED,
     REJECTED,
-    DELETE_REQUESTED
+    DELETE_REQUESTED,
+    ARCHIVED
 }

--- a/src/main/java/com/example/airbnbproject/domain/Payment.java
+++ b/src/main/java/com/example/airbnbproject/domain/Payment.java
@@ -8,10 +8,15 @@ import java.time.LocalDateTime;
 
 @Entity
 @Getter @Setter
-@Table(indexes = {
-        @Index(name = "idx_payment_reservation", columnList = "reservation_id"),
-        @Index(name = "idx_payment_tid",        columnList = "tid") // ✅ 일반 인덱스
-})
+@Table(
+        indexes = {
+                @Index(name = "idx_payment_reservation", columnList = "reservation_id"),
+                @Index(name = "idx_payment_tid",        columnList = "tid")
+        },
+        uniqueConstraints = {
+                @UniqueConstraint(name = "uk_payment_tid_status", columnNames = {"tid", "status"})
+        }
+)
 public class Payment {
 
     @Id
@@ -28,11 +33,10 @@ public class Payment {
     @Column(nullable = false)
     private PaymentStatus status;
 
-    @Column(length = 100) // ✅ unique 제거 (nullable은 기본 true)
+    @Column(length = 100)
     private String tid;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "reservation_id", nullable = false)
     private Reservation reservation;
 }
-

--- a/src/main/java/com/example/airbnbproject/interceptor/LoginCheckInterceptor.java
+++ b/src/main/java/com/example/airbnbproject/interceptor/LoginCheckInterceptor.java
@@ -41,7 +41,8 @@ public class LoginCheckInterceptor implements HandlerInterceptor {
             String query = req.getQueryString();
             String next = current + (query != null ? "?" + query : "");
             String encoded = URLEncoder.encode(next, StandardCharsets.UTF_8.name());
-            res.sendRedirect("/login?next=" + encoded);
+//            res.sendRedirect("/login?next=" + encoded);
+            res.sendRedirect("/?auth=login&next=" + encoded);
             return false;
         }
 

--- a/src/main/java/com/example/airbnbproject/repository/PaymentRepository.java
+++ b/src/main/java/com/example/airbnbproject/repository/PaymentRepository.java
@@ -10,7 +10,7 @@ import java.util.Optional;
 
 @Repository
 public interface PaymentRepository extends JpaRepository<Payment, Long> {
-    boolean existsByTid(String tid);
+    boolean existsByTidAndStatus(String tid, PaymentStatus status);
     Optional<Payment> findTopByReservationAndStatusOrderByPaymentDateDesc(Reservation reservation, PaymentStatus status);
 }
 

--- a/src/main/java/com/example/airbnbproject/repository/UserRepository.java
+++ b/src/main/java/com/example/airbnbproject/repository/UserRepository.java
@@ -18,7 +18,7 @@ public interface UserRepository extends JpaRepository<User, Long> {
                u.id, u.loginId, u.email, u.createdAt
            )
            from User u
-           order by u.createdAt desc
+           order by u.createdAt asc
            """)
     List<AdminUserRowDto> findAdminUserRows();
 }

--- a/src/main/java/com/example/airbnbproject/service/AccommodationInfoService.java
+++ b/src/main/java/com/example/airbnbproject/service/AccommodationInfoService.java
@@ -20,6 +20,7 @@ public class AccommodationInfoService {
 
     private final AccommodationInfoRepository accommodationInfoRepository;
 
+    @Transactional
     public void saveAccommodationInfo(AccommodationInfoRequestDto dto, Accommodation accommodation) throws IOException {
         if (accommodation == null) {
             throw new IllegalArgumentException("연결할 숙소 정보가 없습니다.");
@@ -56,13 +57,9 @@ public class AccommodationInfoService {
             }
         }
 
-        info.setImages(imageList); // 리스트 설정
+        info.setImages(imageList);
 
         accommodationInfoRepository.save(info); // cascade = ALL로 이미지도 같이 저장됨
-    }
-
-    public boolean existsByAccommodationId(Long accommodationId) {
-        return accommodationInfoRepository.existsByAccommodationId(accommodationId);
     }
 
     public AccommodationInfo findById(Long id) {
@@ -70,6 +67,7 @@ public class AccommodationInfoService {
                 .orElseThrow(() -> new IllegalArgumentException("상세정보 없음"));
     }
 
+    @Transactional
     public void update(Long infoId, AccommodationInfoRequestDto dto) throws IOException {
         AccommodationInfo info = findById(infoId);
         info.setTitle(dto.getTitle());

--- a/src/main/java/com/example/airbnbproject/service/AccommodationService.java
+++ b/src/main/java/com/example/airbnbproject/service/AccommodationService.java
@@ -9,6 +9,7 @@ import com.example.airbnbproject.repository.AccommodationRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
 @Service
 @RequiredArgsConstructor
 public class AccommodationService {
@@ -18,7 +19,7 @@ public class AccommodationService {
     @Transactional
     public Accommodation saveAccommodation(AccommodationRequestDto dto, User user) {
         Accommodation acc = Accommodation.of(dto, user);
-
+        // 생성 직후 상태는 기존 도메인 규칙 그대로 사용(예: PENDING)
         return accommodationRepository.save(acc);
     }
 
@@ -28,8 +29,13 @@ public class AccommodationService {
                 .orElseThrow(() -> new IllegalArgumentException("숙소가 존재하지 않습니다."));
 
         // 권한: 본인 또는 관리자만
-        if (!ac.getUser().getId().equals(user.getId()) && user.getRole() != UserRole.ADMIN) {
+        if (!isOwnerOrAdmin(ac, user)) {
             throw new IllegalArgumentException("권한이 없습니다.");
+        }
+
+        // ARCHIVED 는 편집 불가(기록 보존 상태)
+        if (ac.getStatus() == AccommodationStatus.ARCHIVED) {
+            throw new IllegalArgumentException("보존(ARCHIVED)된 숙소는 수정할 수 없습니다.");
         }
 
         // 필드 변경 — 트랜잭션 종료 시점에 dirty checking으로 UPDATE 반영
@@ -38,38 +44,75 @@ public class AccommodationService {
         ac.setImage(dto.getImage());
     }
 
+    /**
+     * 호스트가 "삭제 요청" 버튼을 눌렀을 때 상태만 변경.
+     */
     @Transactional
     public void requestDelete(Long id, User user) {
         Accommodation ac = accommodationRepository.findById(id)
                 .orElseThrow(() -> new IllegalArgumentException("숙소가 존재하지 않습니다."));
 
-        if (!ac.getUser().getId().equals(user.getId())) {
+        if (!isOwner(ac, user)) {
             throw new IllegalArgumentException("권한이 없습니다.");
+        }
+
+        if (ac.getStatus() == AccommodationStatus.ARCHIVED) {
+            throw new IllegalArgumentException("이미 보존(ARCHIVED)된 숙소입니다.");
         }
 
         ac.setStatus(AccommodationStatus.DELETE_REQUESTED);
     }
 
+    /**
+     * (관리자 전용) 삭제 승인 시 — 물리 삭제 대신 ARCHIVED 로 전환.
+     * 예약 이력의 유무와 상관없이 운영 일관성을 위해 '항상' ARCHIVED 로 통일.
+     * 필요하면 정책에 맞게 분기(이력 없으면 물리삭제)로 바꿀 수 있으나, 현재 요구는 "물리삭제 금지".
+     */
     @Transactional
-    public void deleteApproved(Long id, User user) {
+    public void deleteApproved(Long id, User admin) {
         Accommodation ac = accommodationRepository.findById(id)
                 .orElseThrow(() -> new IllegalArgumentException("숙소가 존재하지 않습니다."));
 
-        if (user == null || user.getRole() != UserRole.ADMIN) {
+        if (!isAdmin(admin)) {
             throw new IllegalArgumentException("권한이 없습니다.");
         }
 
-        accommodationRepository.delete(ac);
+        // 이미 ARCHIVED 인 경우 중복 처리 방지
+        if (ac.getStatus() == AccommodationStatus.ARCHIVED) {
+            return;
+        }
+
+        ac.setStatus(AccommodationStatus.ARCHIVED);
+        // 물리 삭제는 절대 하지 않음.
     }
+
     @Transactional(readOnly = true)
     public Accommodation getForEdit(Long id, User user) {
         Accommodation ac = accommodationRepository.findById(id)
                 .orElseThrow(() -> new IllegalArgumentException("숙소가 존재하지 않습니다."));
+
         // 수정 폼 진입 권한: 소유자 또는 관리자
-        if (!ac.getUser().getId().equals(user.getId()) && user.getRole() != UserRole.ADMIN) {
+        if (!isOwnerOrAdmin(ac, user)) {
             throw new IllegalArgumentException("권한이 없습니다.");
         }
+
+        // ARCHIVED 는 편집 폼 진입도 차단(읽기 전용이 필요하면 별도 뷰에서 처리)
+        if (ac.getStatus() == AccommodationStatus.ARCHIVED && !isAdmin(user)) {
+            throw new IllegalArgumentException("보존(ARCHIVED)된 숙소는 편집할 수 없습니다.");
+        }
+
         return ac;
     }
 
+    private boolean isOwnerOrAdmin(Accommodation ac, User user) {
+        return isOwner(ac, user) || isAdmin(user);
+    }
+
+    private boolean isOwner(Accommodation ac, User user) {
+        return user != null && ac.getUser().getId().equals(user.getId());
+    }
+
+    private boolean isAdmin(User user) {
+        return user != null && user.getRole() == UserRole.ADMIN;
+    }
 }

--- a/src/main/java/com/example/airbnbproject/service/AuthService.java
+++ b/src/main/java/com/example/airbnbproject/service/AuthService.java
@@ -7,8 +7,8 @@ import com.example.airbnbproject.repository.UserRepository;
 import com.example.airbnbproject.util.SHA256;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
-import javax.transaction.Transactional;
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -14,20 +14,20 @@ spring:
         format_sql: true
         dialect: org.hibernate.dialect.MySQL8Dialect
 
-  kakaopay:
-    host: https://open-api.kakaopay.com/online
-    secret-key: ${KAKAO_SECRET_KEY}
-    cid: TC0ONETIME
-    approval-url: http://localhost:8080/payment/success
-    cancel-url: http://localhost:8080/payment/cancel
-    fail-url: http://localhost:8080/payment/fail
-
   redis:
     host: localhost
     port: 6379
 
+kakaopay:
+  host: https://open-api.kakaopay.com/online
+  secret-key: ${KAKAO_SECRET_KEY}
+  cid: TC0ONETIME
+  approval-url: http://localhost:8080/payment/success
+  cancel-url:   http://localhost:8080/payment/cancel
+  fail-url:     http://localhost:8080/payment/fail
+
 redisson:
   address: redis://localhost:6379
   lock:
-    lease-seconds: 5   # 락 자동 해제 시간 (임계영역이 5초 넘으면 늘리기)
-    wait-seconds: 3    # 락 대기 최대 시간
+    lease-seconds: 5
+    wait-seconds: 3

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -1,0 +1,5 @@
+spring:
+  jpa:
+    hibernate:
+      ddl-auto: validate
+    show-sql: false

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,9 +2,6 @@ spring:
   application:
     name: AirbnbProject
 
-  profiles:
-    active: dev
-
   mvc:
     view:
       prefix: /WEB-INF/views/
@@ -15,7 +12,15 @@ spring:
       enabled: true
 
   config:
-    import: optional:application-secret.yml
+    import: optional:file:./config/application-secret.yml
 
 server:
   port: 8080
+  servlet:
+    encoding:
+      charset: UTF-8
+  error:
+    whitelabel:
+      enabled: false
+    include-message: never
+    include-binding-errors: never

--- a/src/main/resources/static/css/404.css
+++ b/src/main/resources/static/css/404.css
@@ -1,0 +1,6 @@
+.error-card{
+    border-color:#e6ecff;
+    background: linear-gradient(180deg, #ffffff, #fbfdff 60%);
+}
+.error-title{ color:#1f4fd1; }
+.error-emoji{ filter: saturate(1.2); }

--- a/src/main/resources/static/css/500.css
+++ b/src/main/resources/static/css/500.css
@@ -1,0 +1,6 @@
+.error-card{
+    border-color:#ffe0e0;
+    background: linear-gradient(180deg, #ffffff, #fff7f7 60%);
+}
+.error-title{ color:#B32505; }
+.error-emoji{ filter: saturate(1.1); }

--- a/src/main/resources/static/css/error.css
+++ b/src/main/resources/static/css/error.css
@@ -1,0 +1,71 @@
+@import url('https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@400;600;700&display=swap');
+
+:root{
+    --page-w: 900px;
+    --radius: 14px;
+
+    --text: #222;
+    --muted: #707070;
+    --bg: #fff;
+    --bg-subtle: #fafafa;
+    --border-color: #eee;
+
+    --accent: #FF385C;
+    --acc-1: #E61E4D;
+    --acc-2: #E31C5F;
+    --acc-3: #D70466;
+
+    --danger: #B32505;
+
+    --shadow: 0 8px 24px rgba(0,0,0,.06);
+}
+
+body{
+    font-family:'Noto Sans KR',system-ui,-apple-system,Segoe UI,Roboto,Arial;
+    color:var(--text); background:var(--bg);
+    margin:0;
+}
+
+.error-page{
+    max-width: var(--page-w);
+    margin: 48px auto;
+    padding: 0 24px 48px;
+}
+
+.error-card{
+    padding: 28px 28px 32px;
+    border:1px solid var(--border-color);
+    border-radius: var(--radius);
+    background:#fff;
+    box-shadow: var(--shadow);
+    text-align:center;
+}
+
+.error-emoji{ font-size:48px; margin-bottom:10px; }
+.error-title{ margin:6px 0 10px; font-size:26px; font-weight:800; }
+.error-desc{ color:var(--muted); margin:6px 0 18px; }
+
+.error-meta{
+    list-style:none; padding:0; margin:0 0 20px 0;
+    display:inline-block; text-align:left;
+}
+.error-meta li{
+    padding:6px 0; border-bottom:1px dashed #eee; font-size:14px;
+}
+.error-meta b{ display:inline-block; width:92px; color:#555; }
+
+.error-actions{ display:flex; gap:10px; justify-content:center; }
+
+.btn{
+    padding:10px 14px; border-radius:12px; border:1px solid #ddd;
+    background:#fff; color:#222; cursor:pointer; font-weight:700; text-decoration:none;
+    transition: filter .15s ease, transform .03s ease, border-color .15s ease, box-shadow .15s ease;
+}
+.btn:hover{ border-color:#cfcfcf; }
+.btn:active{ transform: translateY(1px); }
+.btn.primary{
+    background: var(--accent);
+    border-color: var(--accent);
+    color:#fff;
+}
+.btn.outline{ background:#fff; color:#444; }

--- a/src/main/webapp/WEB-INF/views/accommodationEdit.jsp
+++ b/src/main/webapp/WEB-INF/views/accommodationEdit.jsp
@@ -20,6 +20,7 @@
         </c:if>
 
         <form:form method="post" action="/accommodation/update" modelAttribute="accommodationRequestDto" class="form">
+            <input type="hidden" name="_csrf" value="${sessionScope.csrfToken}">
             <input type="hidden" name="id" value="${accommodation.id}"/>
 
             <div class="form-row">

--- a/src/main/webapp/WEB-INF/views/accommodationInfoForm.jsp
+++ b/src/main/webapp/WEB-INF/views/accommodationInfoForm.jsp
@@ -26,6 +26,7 @@
         <form:form modelAttribute="accommodationInfoRequestDto"
                    method="post" enctype="multipart/form-data"
                    action="${formAction}" class="form">
+            <input type="hidden" name="_csrf" value="${sessionScope.csrfToken}">
 
             <div class="form-row">
                 <label>제목</label>

--- a/src/main/webapp/WEB-INF/views/accommodationRegistration.jsp
+++ b/src/main/webapp/WEB-INF/views/accommodationRegistration.jsp
@@ -20,6 +20,8 @@
         </c:if>
 
         <form:form method="post" modelAttribute="accommodationRequestDto" action="/accommodation/register" class="form">
+            <input type="hidden" name="_csrf" value="${sessionScope.csrfToken}">
+
             <div class="form-row">
                 <label for="name">숙소명</label>
                 <form:input path="name" id="name" cssClass="input"/>

--- a/src/main/webapp/WEB-INF/views/accountDelete.jsp
+++ b/src/main/webapp/WEB-INF/views/accountDelete.jsp
@@ -21,6 +21,7 @@
         </p>
 
         <form:form method="post" modelAttribute="accountDeleteRequestDto" action="/account/delete" cssClass="form">
+            <input type="hidden" name="_csrf" value="${sessionScope.csrfToken}">
             <form:errors cssClass="alert" element="div"/>
 
             <div class="form-row">

--- a/src/main/webapp/WEB-INF/views/admin.jsp
+++ b/src/main/webapp/WEB-INF/views/admin.jsp
@@ -105,7 +105,7 @@
             <!-- 숙소 승인/반려 관리 -->
             <section class="pane-card" data-panel="accommodations" ${tab != 'accommodations' ? 'hidden' : ''}>
                 <div class="pane-title-row">
-                    <h2 class="pane-title">숙소 승인/반려 관리</h2>
+                    <h2 class="pane-title">숙소 승인/반려/보존(삭제요청) 관리</h2>
                 </div>
 
                 <div class="table-wrap">
@@ -115,6 +115,7 @@
                             <th>숙소명</th>
                             <th>호스트</th>
                             <th>상태</th>
+                            <th class="th-actions">상세</th>
                             <th class="th-actions">승인</th>
                             <th class="th-actions">반려</th>
                             <th class="th-actions">삭제 승인</th>
@@ -127,38 +128,58 @@
                                 <td>${ac.hostLoginId}</td>
                                 <td>
                                     <c:choose>
-                                        <c:when test="${ac.status == 'APPROVED'}"><span class="badge ok">APPROVED</span></c:when>
-                                        <c:when test="${ac.status == 'PENDING'}"><span class="badge pending">PENDING</span></c:when>
-                                        <c:when test="${ac.status == 'REJECTED'}"><span class="badge danger">REJECTED</span></c:when>
-                                        <c:when test="${ac.status == 'DELETE_REQUESTED'}"><span class="badge warn">DELETE_REQUESTED</span></c:when>
+                                        <c:when test="${ac.status.name() == 'APPROVED'}"><span class="badge ok">APPROVED</span></c:when>
+                                        <c:when test="${ac.status.name() == 'PENDING'}"><span class="badge pending">PENDING</span></c:when>
+                                        <c:when test="${ac.status.name() == 'REJECTED'}"><span class="badge danger">REJECTED</span></c:when>
+                                        <c:when test="${ac.status.name() == 'DELETE_REQUESTED'}"><span class="badge warn">DELETE_REQUESTED</span></c:when>
+                                        <c:when test="${ac.status.name() == 'ARCHIVED'}"><span class="badge muted">ARCHIVED</span></c:when>
                                         <c:otherwise><span class="badge">${ac.status}</span></c:otherwise>
                                     </c:choose>
                                 </td>
+
+                                <td class="td-actions">
+                                    <a class="btn outline" href="/accommodation/${ac.id}">보기</a>
+                                </td>
+
+                                <!-- 승인 버튼: ARCHIVED이면 비활성 -->
                                 <td class="td-actions">
                                     <form method="post" action="/admin/accommodations/approve/${ac.id}">
-                                        <button type="submit" class="btn primary">승인</button>
+                                        <input type="hidden" name="_csrf" value="${sessionScope.csrfToken}">
+                                        <button type="submit" class="btn primary"
+                                            ${ac.status.name() == 'APPROVED' || ac.status.name() == 'ARCHIVED' ? 'disabled' : ''}>
+                                            승인
+                                        </button>
                                     </form>
                                 </td>
 
-                                <!-- 반려 -->
+                                <!-- 반려 버튼: ARCHIVED이면 비활성 -->
                                 <td class="td-actions">
-                                    <c:if test="${ac.status == 'PENDING'}">
-                                        <form method="post" action="/admin/accommodations/reject/${ac.id}">
-                                            <button type="submit" class="btn outline">반려</button>
-                                        </form>
-                                    </c:if>
+                                    <form method="post" action="/admin/accommodations/reject/${ac.id}">
+                                        <input type="hidden" name="_csrf" value="${sessionScope.csrfToken}">
+                                        <button type="submit" class="btn outline"
+                                            ${ac.status.name() == 'REJECTED' || ac.status.name() == 'ARCHIVED' ? 'disabled' : ''}>
+                                            반려
+                                        </button>
+                                    </form>
                                 </td>
 
-                                <!-- 삭제 승인/취소 -->
+                                <!-- 삭제 승인/취소: DELETE_REQUESTED 일 때만 노출, ARCHIVED면 아무 동작 없음 -->
                                 <td class="td-actions">
-                                    <c:if test="${ac.status == 'DELETE_REQUESTED'}">
-                                        <form method="post" action="/admin/accommodation/delete/approve/${ac.id}" onsubmit="return confirm('정말 삭제하시겠습니까?');">
-                                            <button type="submit" class="btn danger">삭제 승인</button>
-                                        </form>
-                                        <form method="post" action="/admin/accommodation/delete/cancel/${ac.id}" onsubmit="return confirm('삭제 요청을 취소하시겠습니까?');">
-                                            <button type="submit" class="btn outline">삭제 취소</button>
-                                        </form>
-                                    </c:if>
+                                    <c:choose>
+                                        <c:when test="${ac.status == 'DELETE_REQUESTED'}">
+                                            <form method="post" action="/admin/accommodation/delete/approve/${ac.id}" onsubmit="return confirm('해당 숙소를 보존(ARCHIVED) 상태로 전환하시겠습니까?');">
+                                                <input type="hidden" name="_csrf" value="${sessionScope.csrfToken}">
+                                                <button type="submit" class="btn danger">삭제 승인(보존 전환)</button>
+                                            </form>
+                                            <form method="post" action="/admin/accommodation/delete/cancel/${ac.id}" onsubmit="return confirm('삭제 요청을 취소하시겠습니까?');">
+                                                <input type="hidden" name="_csrf" value="${sessionScope.csrfToken}">
+                                                <button type="submit" class="btn outline">삭제 취소</button>
+                                            </form>
+                                        </c:when>
+                                        <c:otherwise>
+                                            <span class="muted">-</span>
+                                        </c:otherwise>
+                                    </c:choose>
                                 </td>
                             </tr>
                         </c:forEach>
@@ -166,6 +187,7 @@
                     </table>
                 </div>
             </section>
+
         </main>
     </div>
 </div>

--- a/src/main/webapp/WEB-INF/views/admin/userReservations.jsp
+++ b/src/main/webapp/WEB-INF/views/admin/userReservations.jsp
@@ -50,11 +50,9 @@
                                     <td>${r.checkOut.format(dtf)}</td>
                                     <td>
                                         <c:choose>
-                                            <c:when test="${r.status == 'PAID'}"><span
-                                                    class="badge ok">예약 완료</span></c:when>
-                                            <c:when test="${r.status == 'RESERVED'}"><span
-                                                    class="badge warn">결제 대기 중</span></c:when>
-                                            <c:when test="${r.status == 'CANCELLED'}"><span class="badge danger">취소됨</span></c:when>
+                                            <c:when test="${r.status.name() == 'PAID'}"><span class="badge ok">예약 완료</span></c:when>
+                                            <c:when test="${r.status.name() == 'RESERVED'}"><span class="badge warn">결제 대기 중</span></c:when>
+                                            <c:when test="${r.status.name() == 'CANCELED'}"><span class="badge danger">취소됨</span></c:when>
                                             <c:otherwise><span class="badge"><c:out
                                                     value="${r.status}"/></span></c:otherwise>
                                         </c:choose>

--- a/src/main/webapp/WEB-INF/views/contactUpdate.jsp
+++ b/src/main/webapp/WEB-INF/views/contactUpdate.jsp
@@ -16,6 +16,7 @@
 
     <div class="form-card">
         <form:form method="post" modelAttribute="contactUpdateRequestDto" action="/account/contact" cssClass="form">
+            <input type="hidden" name="_csrf" value="${sessionScope.csrfToken}">
             <form:errors cssClass="alert" element="div"/>
 
             <div class="form-row">

--- a/src/main/webapp/WEB-INF/views/error/404.jsp
+++ b/src/main/webapp/WEB-INF/views/error/404.jsp
@@ -1,0 +1,33 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
+<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <title>페이지를 찾을 수 없습니다</title>
+    <link rel="stylesheet" href="/css/error.css">
+    <link rel="stylesheet" href="/css/404.css">
+</head>
+<body>
+
+<main class="error-page">
+    <section class="error-card">
+        <div class="error-emoji">🔎</div>
+        <h1 class="error-title">요청하신 페이지를 찾을 수 없습니다</h1>
+        <p class="error-desc">주소가 바뀌었거나, 삭제되었을 수 있어요.</p>
+
+        <ul class="error-meta">
+            <li><b>요청 경로</b> <span><c:out value="${path}"/></span></li>
+            <li><b>상태 코드</b> <span><c:out value="${status}"/></span></li>
+            <c:if test="${not empty message}">
+                <li><b>메시지</b> <span><c:out value="${message}"/></span></li>
+            </c:if>
+        </ul>
+
+        <div class="error-actions">
+            <a class="btn" href="/">메인으로</a>
+            <a class="btn outline" href="javascript:history.back()">이전 페이지</a>
+        </div>
+    </section>
+</main>
+</body>
+</html>

--- a/src/main/webapp/WEB-INF/views/error/500.jsp
+++ b/src/main/webapp/WEB-INF/views/error/500.jsp
@@ -1,0 +1,35 @@
+<%@ page pageEncoding="UTF-8" %>
+<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core"%>
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8" />
+    <title>서버 오류가 발생했습니다</title>
+    <link rel="stylesheet" href="/css/error.css">
+    <link rel="stylesheet" href="/css/error.css">
+</head>
+<body>
+<main class="error-page">
+    <section class="error-card">
+        <div class="error-emoji">🚧</div>
+        <h1 class="error-title">서버 오류가 발생했습니다</h1>
+        <p class="error-desc">잠시 후 다시 시도해주세요. 문제가 지속되면 관리자에게 문의하세요.</p>
+
+        <ul class="error-meta">
+            <li><b>상태 코드</b> <span><c:out value="${status}"/></span></li>
+            <c:if test="${not empty message}">
+                <li><b>메시지</b> <span><c:out value="${message}"/></span></li>
+            </c:if>
+            <c:if test="${not empty path}">
+                <li><b>경로</b> <span><c:out value="${path}"/></span></li>
+            </c:if>
+        </ul>
+
+        <div class="error-actions">
+            <a class="btn" href="/">메인으로</a>
+            <a class="btn outline" href="javascript:history.back()">이전 페이지</a>
+        </div>
+    </section>
+</main>
+</body>
+</html>

--- a/src/main/webapp/WEB-INF/views/error/error.jsp
+++ b/src/main/webapp/WEB-INF/views/error/error.jsp
@@ -1,0 +1,34 @@
+<%@ page pageEncoding="UTF-8" %>
+<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core"%>
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8" />
+    <title>요청을 처리할 수 없습니다</title>
+    <link rel="stylesheet" href="/css/error.css">
+</head>
+<body>
+<main class="error-page">
+    <section class="error-card">
+        <div class="error-emoji">🙇</div>
+        <h1 class="error-title">요청을 처리할 수 없습니다</h1>
+        <p class="error-desc">요청을 처리하는 중 오류가 발생했습니다.</p>
+
+        <ul class="error-meta">
+            <li><b>상태 코드</b> <span><c:out value="${status}"/></span></li>
+            <c:if test="${not empty message}">
+                <li><b>메시지</b> <span><c:out value="${message}"/></span></li>
+            </c:if>
+            <c:if test="${not empty path}">
+                <li><b>경로</b> <span><c:out value="${path}"/></span></li>
+            </c:if>
+        </ul>
+
+        <div class="error-actions">
+            <a class="btn" href="/">메인으로</a>
+            <a class="btn outline" href="javascript:history.back()">이전 페이지</a>
+        </div>
+    </section>
+</main>
+</body>
+</html>

--- a/src/main/webapp/WEB-INF/views/layout/header.jsp
+++ b/src/main/webapp/WEB-INF/views/layout/header.jsp
@@ -1,122 +1,128 @@
-<%@ page contentType="text/html;charset=UTF-8" language="java" %>
-<%@ page import="com.example.airbnbproject.domain.User" %>
+<%@ page pageEncoding="UTF-8" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
 
-<%
-  User user = (User) session.getAttribute("user");
-%>
-
 <div class="header-container">
-  <div class="logo">
-    <a href="/"><img src="/images/logo.png" alt="로고"></a>
-  </div>
-
-  <form class="search-form" action="/search" method="get">
-    <input type="text" name="searchName" placeholder="어디든지 | 언제든 일주일 | 게스트추가">
-    <button type="submit" aria-label="검색">
-      <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="white" class="bi bi-search" viewBox="0 0 16 16">
-        <path d="M11.742 10.344a6.5 6.5 0 1 0-1.397 1.398l3.85 3.85a1 1 0 1 0 1.415-1.414l-3.85-3.85zM12 6.5a5.5 5.5 0 1 1-11 0 5.5 5.5 0 0 1 11 0z"/>
-      </svg>
-    </button>
-  </form>
-
-  <div class="airbnb-msg">당신의 공간을 에어비앤비하세요</div>
-
-  <div class="user-actions">
-    <!-- 메뉴 드롭다운 -->
-    <div class="menu dropdown-wrap">
-      <button class="dropdown-btn" type="button" onclick="toggleDropdown('menuDropdown')" aria-haspopup="true" aria-expanded="false" aria-controls="menuDropdown">
-        <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="black" class="bi bi-list" viewBox="0 0 16 16">
-          <path d="M2.5 12a.5.5 0 0 1 .5-.5h10a.5.5 0 0 1 0 1H3a.5.5 0 0 1-.5-.5zm0-4a.5.5 0 0 1 .5-.5h10a.5.5 0 0 1 0 1H3a.5.5 0 0 1-.5-.5zm0-4a.5.5 0 0 1 .5-.5h10a.5.5 0 0 1 0 1H3a.5.5 0 0 1-.5-.5z"/>
-        </svg>
-      </button>
-      <ul class="dropdown-menu" id="menuDropdown">
-        <c:choose>
-          <c:when test="${user != null}">
-            <li><a href="/account">마이페이지</a></li>
-            <li>
-              <a href="#" id="logoutLink">로그아웃</a>
-              <form id="logoutForm" action="/logout" method="post" style="display:none"></form>
-            </li>
-            <c:if test="${user.role == 'ADMIN'}">
-              <li><a href="/admin">관리자 메뉴</a></li>
-            </c:if>
-          </c:when>
-          <c:otherwise>
-            <!-- auth-open 링크: 공용 auth.jsp가 이벤트 잡아서 모달 오픈 -->
-            <li><a href="/?auth=join"  class="auth-open" data-auth="join">회원가입</a></li>
-            <li><a href="/?auth=login" class="auth-open" data-auth="login">로그인</a></li>
-          </c:otherwise>
-        </c:choose>
-      </ul>
+    <div class="logo">
+        <a href="/"><img src="/images/logo.png" alt="로고"></a>
     </div>
 
-    <!-- 사용자 드롭다운 -->
-    <div class="menu dropdown-wrap">
-      <button class="dropdown-btn" type="button" onclick="toggleDropdown('userDropdown')" aria-haspopup="true" aria-expanded="false" aria-controls="userDropdown">
-        <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="black" class="bi bi-person-circle" viewBox="0 0 16 16">
-          <path d="M11 6a3 3 0 1 1-6 0 3 3 0 0 1 6 0z"/>
-          <path fill-rule="evenodd" d="M0 8a8 8 0 1 1 16 0A8 8 0 0 1 0 8zm8-7a7 7 0 0 0-5.468 11.37C3.242 11.226 4.805 10 8 10s4.757 1.225 5.468 2.37A7 7 0 0 0 8 1z"/>
-        </svg>
-      </button>
-      <ul class="dropdown-menu" id="userDropdown">
-        <c:choose>
-          <c:when test="${user != null}">
-            <li><a href="/account">마이페이지</a></li>
-            <li>
-              <a href="#" id="logoutLink2">로그아웃</a>
-              <form id="logoutForm2" action="/logout" method="post" style="display:none"></form>
-            </li>
-            <c:if test="${user.role == 'ADMIN'}">
-              <li><a href="/admin">관리자 메뉴</a></li>
-            </c:if>
-          </c:when>
-          <c:otherwise>
-            <li><a href="/?auth=join"  class="auth-open" data-auth="join">회원가입</a></li>
-            <li><a href="/?auth=login" class="auth-open" data-auth="login">로그인</a></li>
-          </c:otherwise>
-        </c:choose>
-      </ul>
+    <form class="search-form" action="/search" method="get">
+        <input type="text" name="searchName" placeholder="어디든지 | 언제든 일주일 | 게스트추가">
+        <button type="submit" aria-label="검색">
+            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="white" class="bi bi-search" viewBox="0 0 16 16">
+                <path d="M11.742 10.344a6.5 6.5 0 1 0-1.397 1.398l3.85 3.85a1 1 0 1 0 1.415-1.414l-3.85-3.85zM12 6.5a5.5 5.5 0 1 1-11 0 5.5 5.5 0 0 1 11 0z"/>
+            </svg>
+        </button>
+    </form>
+
+    <div class="airbnb-msg">당신의 공간을 에어비앤비하세요</div>
+
+    <div class="user-actions">
+        <!-- 메뉴 드롭다운 -->
+        <div class="menu dropdown-wrap">
+            <button class="dropdown-btn" type="button" onclick="toggleDropdown('menuDropdown')" aria-haspopup="true"
+                    aria-expanded="false" aria-controls="menuDropdown">
+                <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="black" class="bi bi-list" viewBox="0 0 16 16">
+                    <path d="M2.5 12a.5.5 0 0 1 .5-.5h10a.5.5 0 0 1 0 1H3a.5.5 0 0 1-.5-.5zm0-4a.5.5 0 0 1 .5-.5h10a.5.5 0 0 1 0 1H3a.5.5 0 0 1-.5-.5zm0-4a.5.5 0 0 1 .5-.5h10a.5.5 0 0 1 0 1H3a.5.5 0 0 1-.5-.5z"/>
+                </svg>
+            </button>
+            <ul class="dropdown-menu" id="menuDropdown">
+                <c:choose>
+                    <c:when test="${sessionScope.user != null}">
+                        <li><a href="/account">마이페이지</a></li>
+                        <li>
+                            <a href="#" id="logoutLink">로그아웃</a>
+                            <form id="logoutForm" action="/logout" method="post" style="display:none">
+                                <input type="hidden" name="_csrf" value="${sessionScope.csrfToken}">
+                            </form>
+                        </li>
+                        <c:if test="${sessionScope.user.role == 'ADMIN'}">
+                            <li><a href="/admin">관리자 메뉴</a></li>
+                        </c:if>
+                    </c:when>
+                    <c:otherwise>
+                        <li><a href="/?auth=join" class="auth-open" data-auth="join">회원가입</a></li>
+                        <li><a href="/?auth=login" class="auth-open" data-auth="login">로그인</a></li>
+                    </c:otherwise>
+                </c:choose>
+            </ul>
+        </div>
+
+        <!-- 사용자 드롭다운 -->
+        <div class="menu dropdown-wrap">
+            <button class="dropdown-btn" type="button" onclick="toggleDropdown('userDropdown')" aria-haspopup="true"
+                    aria-expanded="false" aria-controls="userDropdown">
+                <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="black" class="bi bi-person-circle" viewBox="0 0 16 16">
+                    <path d="M11 6a3 3 0 1 1-6 0 3 3 0 0 1 6 0z"/>
+                    <path fill-rule="evenodd" d="M0 8a8 8 0 1 1 16 0A8 8 0 0 1 0 8zm8-7a7 7 0 0 0-5.468 11.37C3.242 11.226 4.805 10 8 10s4.757 1.225 5.468 2.37A7 7 0 0 0 8 1z"/>
+                </svg>
+            </button>
+            <ul class="dropdown-menu" id="userDropdown">
+                <c:choose>
+                    <c:when test="${sessionScope.user != null}">
+                        <li><a href="/account">마이페이지</a></li>
+                        <li>
+                            <a href="#" id="logoutLink2">로그아웃</a>
+                            <form id="logoutForm2" action="/logout" method="post" style="display:none">
+                                <input type="hidden" name="_csrf" value="${sessionScope.csrfToken}">
+                            </form>
+                        </li>
+                        <c:if test="${sessionScope.user.role == 'ADMIN'}">
+                            <li><a href="/admin">관리자 메뉴</a></li>
+                        </c:if>
+                    </c:when>
+                    <c:otherwise>
+                        <li><a href="/?auth=join" class="auth-open" data-auth="join">회원가입</a></li>
+                        <li><a href="/?auth=login" class="auth-open" data-auth="login">로그인</a></li>
+                    </c:otherwise>
+                </c:choose>
+            </ul>
+        </div>
     </div>
-  </div>
 </div>
 
 <script>
-  // 드롭다운
-  function toggleDropdown(id) {
-    const target = document.getElementById(id);
-    target.classList.toggle('show');
-    document.querySelectorAll('.dropdown-menu').forEach(menu => {
-      if (menu.id !== id) menu.classList.remove('show');
+    // 드롭다운
+    function toggleDropdown(id) {
+        const target = document.getElementById(id);
+        target.classList.toggle('show');
+        document.querySelectorAll('.dropdown-menu').forEach(menu => {
+            if (menu.id !== id) menu.classList.remove('show');
+        });
+    }
+    window.addEventListener('click', function (e) {
+        if (!e.target.closest('.dropdown-wrap')) {
+            document.querySelectorAll('.dropdown-menu').forEach(menu => menu.classList.remove('show'));
+        }
     });
-  }
-  window.addEventListener('click', function(e) {
-    if (!e.target.closest('.dropdown-wrap')) {
-      document.querySelectorAll('.dropdown-menu').forEach(menu => menu.classList.remove('show'));
-    }
-  });
 
-  // 로그아웃
-  document.addEventListener('click', e => {
-    if (e.target.closest('#logoutLink')) {
-      e.preventDefault(); document.getElementById('logoutForm').submit();
-    }
-    if (e.target.closest('#logoutLink2')) {
-      e.preventDefault(); document.getElementById('logoutForm2').submit();
-    }
-  });
-
-  document.addEventListener('click', function(e){
-    const a = e.target.closest('a.auth-open');
-    if (!a) return;
-    e.preventDefault();
-    const modal = document.getElementById('authModal');
-    if (!modal) { location.href = a.getAttribute('href') || '/?auth=login'; return; }
-    const which = a.dataset.auth || 'login';
-    modal.hidden = false;
-    document.body.classList.add('auth-no-scroll');
-    modal.querySelectorAll('.auth-panel').forEach(p => {
-      p.hidden = (p.dataset.authPanel !== which);
+    // 로그아웃
+    document.addEventListener('click', e => {
+        if (e.target.closest('#logoutLink')) {
+            e.preventDefault();
+            document.getElementById('logoutForm').submit();
+        }
+        if (e.target.closest('#logoutLink2')) {
+            e.preventDefault();
+            document.getElementById('logoutForm2').submit();
+        }
     });
-  });
+
+    // 인증 모달 오픈(공용)
+    document.addEventListener('click', function (e) {
+        const a = e.target.closest('a.auth-open');
+        if (!a) return;
+        e.preventDefault();
+        const modal = document.getElementById('authModal');
+        if (!modal) {
+            location.href = a.getAttribute('href') || '/?auth=login';
+            return;
+        }
+        const which = a.dataset.auth || 'login';
+        modal.hidden = false;
+        document.body.classList.add('auth-no-scroll');
+        modal.querySelectorAll('.auth-panel').forEach(p => {
+            p.hidden = (p.dataset.authPanel !== which);
+        });
+    });
 </script>

--- a/src/main/webapp/WEB-INF/views/myPage.jsp
+++ b/src/main/webapp/WEB-INF/views/myPage.jsp
@@ -101,6 +101,7 @@
             </section>
 
             <!-- 숙소 관리 -->
+            <!-- 숙소 관리 -->
             <section class="pane-card" data-panel="listings" ${tab != 'listings' ? 'hidden' : ''}>
                 <div class="pane-title-row">
                     <h2 class="pane-title">숙소 관리</h2>
@@ -115,34 +116,48 @@
                                 <tr>
                                     <th>숙소명</th>
                                     <th>가격</th>
+                                    <th>상세</th>
                                     <th>수정</th>
                                     <th>삭제</th>
                                 </tr>
                                 </thead>
                                 <tbody>
                                 <c:forEach var="ac" items="${myAccommodations}">
-                                    <tr>
-                                        <td class="ellipsis">${ac.name}</td>
-                                        <td>₩<fmt:formatNumber value="${ac.price}" type="number"/>원 / 1박</td>
-                                        <td><a class="link" href="/accommodation/edit?id=${ac.id}">수정</a></td>
-                                        <td>
-                                            <c:choose>
-                                                <c:when test="${ac.status == 'APPROVED'}">
-                                                    <form method="post" action="/accommodation/delete"
-                                                          onsubmit="return confirm('숙소 삭제 요청을 하시겠습니까?');">
-                                                        <input type="hidden" name="id" value="${ac.id}"/>
-                                                        <button type="submit" class="btn tiny">삭제 요청</button>
-                                                    </form>
-                                                </c:when>
-                                                <c:when test="${ac.status == 'DELETE_REQUESTED'}">
-                                                    <span class="badge warn">삭제 요청됨 (승인 대기)</span>
-                                                </c:when>
-                                                <c:otherwise>
-                                                    <span class="badge">삭제 불가</span>
-                                                </c:otherwise>
-                                            </c:choose>
-                                        </td>
-                                    </tr>
+                                    <!-- ARCHIVED 숙소는 호스트 화면에서 숨김 -->
+                                    <c:if test="${ac.status != 'ARCHIVED'}">
+                                        <tr>
+                                            <td class="ellipsis">${ac.name}</td>
+                                            <td>₩<fmt:formatNumber value="${ac.price}" type="number"/>원 / 1박</td>
+
+                                            <!-- 숙소 상세보기: 공개 상세 페이지로 이동 -->
+                                            <td>
+                                                <a class="link" href="/accommodation/${ac.id}">열기</a>
+                                            </td>
+
+                                            <td>
+                                                <a class="link" href="/accommodation/edit?id=${ac.id}">수정</a>
+                                            </td>
+
+                                            <td>
+                                                <c:choose>
+                                                    <c:when test="${ac.status == 'APPROVED'}">
+                                                        <form method="post" action="/accommodation/delete"
+                                                              onsubmit="return confirm('숙소 삭제 요청을 하시겠습니까?');">
+                                                            <input type="hidden" name="_csrf" value="${sessionScope.csrfToken}">
+                                                            <input type="hidden" name="id" value="${ac.id}"/>
+                                                            <button type="submit" class="btn tiny">삭제 요청</button>
+                                                        </form>
+                                                    </c:when>
+                                                    <c:when test="${ac.status == 'DELETE_REQUESTED'}">
+                                                        <span class="badge warn">삭제 요청됨 (승인 대기)</span>
+                                                    </c:when>
+                                                    <c:otherwise>
+                                                        <span class="badge">삭제 불가</span>
+                                                    </c:otherwise>
+                                                </c:choose>
+                                            </td>
+                                        </tr>
+                                    </c:if>
                                 </c:forEach>
                                 </tbody>
                             </table>

--- a/src/main/webapp/WEB-INF/views/passwordChange.jsp
+++ b/src/main/webapp/WEB-INF/views/passwordChange.jsp
@@ -6,7 +6,7 @@
 <head>
     <title>비밀번호 변경</title>
     <link rel="stylesheet" href="/css/header.css">
-    <link rel="stylesheet" href="/css/passwordChange.css"><!-- 페이지 전용 -->
+    <link rel="stylesheet" href="/css/passwordChange.css">
 </head>
 <body>
 <%@ include file="layout/header.jsp" %>
@@ -16,7 +16,8 @@
 
     <div class="form-card">
         <form:form method="post" modelAttribute="passwordChangeRequestDto" action="/account/password" cssClass="form">
-            <!-- 폼 상단 공통 에러 -->
+
+            <input type="hidden" name="_csrf" value="${sessionScope.csrfToken}">
             <form:errors cssClass="alert" element="div"/>
 
             <div class="form-row">
@@ -37,7 +38,6 @@
                 <form:errors path="newPasswordConfirm" cssClass="error"/>
             </div>
 
-            <!-- 커스텀 오브젝트 에러 -->
             <form:errors path="confirmMatches" cssClass="error"/>
             <form:errors path="differentFromCurrent" cssClass="error"/>
 

--- a/src/main/webapp/WEB-INF/views/reservation.jsp
+++ b/src/main/webapp/WEB-INF/views/reservation.jsp
@@ -15,15 +15,25 @@
 <div class="reservation-page">
     <h1 class="page-title">예약 상세</h1>
 
-    <!-- 플래시 메시지 -->
+    <c:if test="${not empty errorMsg}">
+        <div class="toast error">${errorMsg}</div>
+    </c:if>
+
     <c:if test="${not empty msg}">
         <div class="toast">${msg}</div>
     </c:if>
 
+    <c:if test="${not empty fieldErrors}">
+        <ul class="form-errors">
+            <c:forEach var="fe" items="${fieldErrors}">
+                <li><strong>${fe.field}</strong> : <c:out value="${fe.defaultMessage}"/></li>
+            </c:forEach>
+        </ul>
+    </c:if>
+
+
     <div class="reservation-card">
-        <!-- 좌측: 예약 요약 -->
         <div class="reservation-left">
-            <!-- 썸네일이 없으므로 심플한 플레이스홀더 -->
             <img class="reservation-img"
                  src="${reservation.image}"
                  alt="숙소 이미지">
@@ -40,7 +50,6 @@
             </div>
         </div>
 
-        <!-- 우측: 상세 정보 + 액션 -->
         <div class="reservation-right">
             <h3 class="section-title">예약 정보</h3>
             <div class="kv">
@@ -60,31 +69,31 @@
                 <span class="v status ${reservation.status}"><c:out value="${reservation.status}"/></span>
             </div>
 
-            <!-- 버튼 영역 -->
             <div class="btn-group">
-                <!-- RESERVED: 결제 & 취소 -->
                 <c:if test="${reservation.status == 'RESERVED'}">
                     <form action="/payment/kakao" method="post">
                         <input type="hidden" name="reservationId" value="${reservation.id}">
+                        <input type="hidden" name="amount" value="${reservation.totalAmount}">
+                        <input type="hidden" name="_csrf" value="${sessionScope.csrfToken}">
                         <button type="submit" class="btn btn-primary">카카오페이로 결제</button>
                     </form>
 
                     <form action="/reservation/${reservation.id}/cancel" method="post">
+                        <input type="hidden" name="_csrf" value="${sessionScope.csrfToken}">
                         <button type="submit" class="btn btn-danger">예약 취소</button>
                     </form>
                 </c:if>
 
-                <!-- PAID: 환불(취소)만 -->
                 <c:if test="${reservation.status == 'PAID'}">
                     <div class="hint">결제가 완료된 예약입니다.</div>
                     <form action="/reservation/${reservation.id}/cancel" method="post">
+                        <input type="hidden" name="_csrf" value="${sessionScope.csrfToken}">
                         <button type="submit" class="btn btn-danger">예약 & 결제 취소</button>
                     </form>
                 </c:if>
 
-                <!-- CANCELED: 안내만 -->
                 <c:if test="${reservation.status == 'CANCELED'}">
-                    <div class="hint">이미 취소된 예약입니다.</div>
+                    <div class="hint">취소가 완료되었습니다.</div>
                 </c:if>
             </div>
         </div>

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -1,0 +1,24 @@
+<!--<?xml version="1.0" encoding="UTF-8"?>-->
+<!--<web-app xmlns="http://xmlns.jcp.org/xml/ns/javaee"-->
+<!--         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"-->
+<!--         xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee-->
+<!--                             http://xmlns.jcp.org/xml/ns/javaee/web-app_3_1.xsd"-->
+<!--         version="3.1">-->
+
+<!--    <jsp-config>-->
+<!--        <jsp-property-group>-->
+<!--            <url-pattern>*.jsp</url-pattern>-->
+<!--            <page-encoding>UTF-8</page-encoding>-->
+
+<!--            &lt;!&ndash; 순서상 여기 먼저 &ndash;&gt;-->
+<!--            <trim-directive-whitespaces>true</trim-directive-whitespaces>-->
+
+<!--            &lt;!&ndash; 그 다음에 default-content-type &ndash;&gt;-->
+<!--            <default-content-type>text/html; charset=UTF-8</default-content-type>-->
+
+<!--            &lt;!&ndash; (선택) 필요하면 buffer, error-on-undeclared-namespace 순서대로 &ndash;&gt;-->
+<!--            &lt;!&ndash; <buffer>8kb</buffer> &ndash;&gt;-->
+<!--            &lt;!&ndash; <error-on-undeclared-namespace>false</error-on-undeclared-namespace> &ndash;&gt;-->
+<!--        </jsp-property-group>-->
+<!--    </jsp-config>-->
+<!--</web-app>-->


### PR DESCRIPTION
### 작업 내용

1. 설정/프로필/시크릿
   - `spring.config.import: optional:file:./config/application-secret.yml` 로 **시크릿 외부화**
   - `application-dev.yml`(개발: `ddl-auto=update`, `show-sql=true`) / `application-prod.yml`(운영: `validate`, `show-sql=false`) **프로필 분리**
   - `KakaoPayConfig` 프로퍼티 바인딩 키 정합성 점검

2. 보안(세션/인터셉터/CSRF)
   - 로그인 성공 시 **세션 재발급**(session fixation 방지)
   - 결제 콜백 `/payment/success|cancel|fail` **인터셉터 예외 경로** 정리
   - 헤더 로그아웃 버튼 **POST + CSRF 폼**으로 변경

3. 검증(Validation) & 사용자 피드백
   - 컨트롤러에 `@Valid + BindingResult` 적용
   - 화면에 **에러 메시지 블록** 추가(기존 toast와 공존)

4. 예약/결제(경합·멱등·상태전이)
   - `Payment` 엔티티에 **복합 UNIQUE** `(tid, status)` 추가 → 동일 TID의 **PAID 중복 승인 차단**, `CANCELED` 로그는 공존
   - `KakaoPayService`: 승인/취소 시 **멱등 처리**(선조회/존재 시 스킵 + 중복 저장 예외 무시)
   - 낙관락 재시도 / Redis 락 사용 구간 유지로 **경합 안정성** 보강

5. 관리자/마이페이지/숙소/뷰 정리
   - 관리자 페이지: 상태별 버튼 가드(ARCHIVED/DISABLED/DELETE_REQUESTED), 표기 정리
   - JSP Enum 비교를 **`.name()` 기반**으로 통일(`admin.jsp`, `admin/userReservations.jsp`)
   - 마이페이지/계정: 연락처·비번·탈퇴 플로우 검증/메시지 보강
   - 숙소 등록/수정/상세 폼: CSRF 확인, 이미지/상세 입력 처리 안정화
   - 예약 화면: 비활성 날짜(Flatpickr) **안정 갱신**

6. 에러 처리/UX
   - `GlobalExceptionHandler` + `CustomErrorController` 추가
   - `WEB-INF/views/error/{404.jsp,500.jsp,error.jsp}` 및 전용 CSS 추가
   - (선택) 400계열 바인딩/유효성 에러 뷰 매핑
